### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pycrypto
+pycryptodome
 requests


### PR DESCRIPTION
Hello, as described in openwrt forum as GoTex - I found out that atleast on windows this "pycrypto" is deprecated, I propose to use "pycryptodome" as it gives no error when pip installing.