### PR TITLE
Windows fixes

### DIFF
--- a/remote_command_execution_vulnerability.py
+++ b/remote_command_execution_vulnerability.py
@@ -42,7 +42,7 @@ with open("speedtest_urls_template.xml", "rt", encoding = "UTF-8") as f:
     template = f.read()
 data = template.format(router_ip_address=router_ip_address, command=command)
 # print(data)
-with open("build/speedtest_urls.xml", "wt", encoding = "UTF-8") as f:
+with open("build/speedtest_urls.xml", "wt", encoding = "UTF-8", newline = "\n") as f:
     f.write(data)
 
 print("****************")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pycryptodome
 requests


### PR DESCRIPTION
The main issue arises from the fact that Windows use CRLF (`\r\n`) as line ending and Unix-like OS's use just LF (`\n`). So, when we save processed `build/speedtest_urls.xml` file all original LF replaced with CRLF. Later on this unwanted excess CR characters can't be properly proceed by the router OS (custom Linux) and exploiting process is falling apart.
Fixes #82, #69 and probably others.

Also remove unused dependency (or am I missing something?).