### PR TITLE
check whether the result is ok by testing the remote port 22

### DIFF
--- a/remote_command_execution_vulnerability.py
+++ b/remote_command_execution_vulnerability.py
@@ -23,6 +23,7 @@ import time
 import random
 import hashlib
 import platform
+import socket
 
 if platform.system() == "Windows":
     sys.exit("Stopping: script can only be run on a Mac/Linux system")
@@ -131,7 +132,37 @@ if use_local_file_server:
 else:  # Use remote github repository. port setted to 0.
     send_test_netspeed_request(router_ip_address, stok, port=0)
 
-print("done! Now you can connect to the router using several options: (user: root, password: root)")
-print("* telnet {}".format(router_ip_address))
-print("* ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -c 3des-cbc -o UserKnownHostsFile=/dev/null root@{}".format(router_ip_address))
-print("* ftp: using a program like cyberduck")
+retry = 3
+delay = 1
+timeout = 3
+def isOpen(ip, port):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    try:
+        s.connect((ip, int(port)))
+        s.shutdown(socket.SHUT_RDWR)
+        return True
+    except:
+        return False
+    finally:
+        s.close()
+
+def checkHost(ip, port):
+    ipup = False
+    for i in range(retry):
+        if isOpen(ip, port):
+            ipup = True
+            break
+        else:
+            time.sleep(delay)
+    return ipup
+
+if checkHost(router_ip_address, 22):
+    print("done! Now you can connect to the router using several options: (user: root, password: root)")
+    print("* telnet {}".format(router_ip_address))
+    print("* ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -c 3des-cbc -o UserKnownHostsFile=/dev/null root@{}".format(router_ip_address))
+    print("* ftp: using a program like cyberduck")
+else:
+    print("Warning: the process has finished, but seems like ssh connection to the router is not working as expected.")
+    print("* Maybe your firmware version is not supported, please have a look at https://github.com/acecilia/OpenWRTInvasion/blob/master/README.md#unsupported-routers-and-firmware-versions")
+    print("* Anyway you can try it with: telnet {}".format(router_ip_address))


### PR DESCRIPTION
As the new firmware of 4A is not supported yet, and it seems quite sure that it won't be supported anymore as the security issue  has been fixed, so it's very important to remind the user strongly, not just put it in the small corner of README. It causes the user in confusion while the result tell them everything goes well but he can't ssh. Maybe we should release a new version, as not everybody read the README very carefully.