### PR TITLE
add WA for modern openssh settings

### DIFF
--- a/remote_command_execution_vulnerability.py
+++ b/remote_command_execution_vulnerability.py
@@ -160,7 +160,7 @@ def checkHost(ip, port):
 if checkHost(router_ip_address, 22):
     print("done! Now you can connect to the router using several options: (user: root, password: root)")
     print("* telnet {}".format(router_ip_address))
-    print("* ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -c 3des-cbc -o UserKnownHostsFile=/dev/null root@{}".format(router_ip_address))
+    print("* ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -oHostKeyAlgorithms=+ssh-rsa -c 3des-cbc -o UserKnownHostsFile=/dev/null root@{}".format(router_ip_address))
     print("* ftp: using a program like cyberduck")
 else:
     print("Warning: the process has finished, but seems like ssh connection to the router is not working as expected.")


### PR DESCRIPTION
First of all, thanks for this amazing repository!

root shell for device `Xiaomi Mi Router 4A (100M International Edition)` with version `3.0.18` works successfully

Some logs of getting shell:

```
$ docker run --network host -it openwrtinvasion
Router IP address [press enter for using the default 'miwifi.com']: router.miwifi.com
Enter router admin password: changemepassword
There two options to provide the files needed for invasion:
   1. Use a local TCP file server runing on random port to provide files in local directory `script_tools`.
   2. Download needed files from remote github repository. (choose this option only if github is accessable inside router device.)
Which option do you prefer? (default: 1)
****************
router_ip_address: router.miwifi.com
stok: 11d2afc5bf598910eac1392995054672
file provider: local file server
****************
start uploading config file...
start exec command...
local file server is runing on 0.0.0.0:39475. root='script_tools'
local file server is getting 'busybox-mipsel' for 192.168.31.1.
local file server is getting 'dropbearStaticMipsel.tar.bz2' for 192.168.31.1.
done! Now you can connect to the router using several options: (user: root, password: root)
* telnet router.miwifi.com
* ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -c 3des-cbc -o UserKnownHostsFile=/dev/null root@router.miwifi.com
* ftp: using a program like cyberduck
```

But ssh command as is didn't trick for modern config of openssh

```
$ ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -c 3des-cbc -o UserKnownHostsFile=/dev/null root@router.miwifi.com
Unable to negotiate with 192.168.31.1 port 22: no matching host key type found. Their offer: ssh-rsa,ssh-dss
```
Passing option `HostKeyAlgorithms=+ssh-rsa` did the trick
```
$ ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -oHostKeyAlgorithms=+ssh-rsa -c 3des-cbc -o UserKnownHostsFile=/dev/null root@router.miwifi.com
The authenticity of host 'router.miwifi.com (192.168.31.1)' can't be established.
RSA key fingerprint is SHA256:BB4AQAipizoqQkQCnM0UoQmsXxjbW0eIIoiCFnzBPOY.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'router.miwifi.com' (RSA) to the list of known hosts.
root@router.miwifi.com's password: 


BusyBox v1.19.4 (2021-11-05 02:48:20 UTC) built-in shell (ash)
Enter 'help' for a list of built-in commands.

 -----------------------------------------------------
       Welcome to XiaoQiang!
 -----------------------------------------------------
  $$$$$$\  $$$$$$$\  $$$$$$$$\      $$\      $$\        $$$$$$\  $$\   $$\
 $$  __$$\ $$  __$$\ $$  _____|     $$ |     $$ |      $$  __$$\ $$ | $$  |
 $$ /  $$ |$$ |  $$ |$$ |           $$ |     $$ |      $$ /  $$ |$$ |$$  /
 $$$$$$$$ |$$$$$$$  |$$$$$\         $$ |     $$ |      $$ |  $$ |$$$$$  /
 $$  __$$ |$$  __$$< $$  __|        $$ |     $$ |      $$ |  $$ |$$  $$<
 $$ |  $$ |$$ |  $$ |$$ |           $$ |     $$ |      $$ |  $$ |$$ |\$$\
 $$ |  $$ |$$ |  $$ |$$$$$$$$\       $$$$$$$$$  |       $$$$$$  |$$ | \$$\
 \__|  \__|\__|  \__|\________|      \_________/        \______/ \__|  \__|


root@XiaoQiang:~#
```

![Thanks](https://media.giphy.com/media/vFKqnCdLPNOKc/giphy.gif)