### PR TITLE
Reduce disk space for docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git/
 firmwares/
 readme/
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM docker.io/library/python:3-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Looks like we can simply reduce disk space for docker image.

Now we have this
```
$ docker build -t openwrtinvasion .
Sending build context to Docker daemon  116.5MB
Step 1/6 : FROM python:3
3: Pulling from library/python
bbeef03cda1f: Pull complete 
f049f75f014e: Pull complete 
56261d0e6b05: Pull complete 
9bd150679dbd: Pull complete 
5b282ee9da04: Pull complete 
03f027d5e312: Pull complete 
591b0f932310: Pull complete 
1047c5f4cc7d: Pull complete 
5b5cbe74bf76: Pull complete 
Digest: sha256:b0b919e3de6ae3cfd0244abc3c0fcb3f3146f4ff0ae7b9c0f59659f92cfbbb7b
Status: Downloaded newer image for python:3
 ---> 63490c269128
Step 2/6 : WORKDIR /app
 ---> Running in edc6a866a4c3
Removing intermediate container edc6a866a4c3
 ---> f1218ec7f817
Step 3/6 : COPY requirements.txt ./
 ---> 44fed244e89b
Step 4/6 : RUN pip install -r requirements.txt
 ---> Running in 0e41a21ddf10
Collecting requests
  Downloading requests-2.28.2-py3-none-any.whl (62 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.8/62.8 kB 1.0 MB/s eta 0:00:00
Collecting charset-normalizer<4,>=2
  Downloading charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (196 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 196.8/196.8 kB 3.2 MB/s eta 0:00:00
Collecting idna<4,>=2.5
  Downloading idna-3.4-py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.5/61.5 kB 4.0 MB/s eta 0:00:00
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.14-py2.py3-none-any.whl (140 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.6/140.6 kB 7.3 MB/s eta 0:00:00
Collecting certifi>=2017.4.17
  Downloading certifi-2022.12.7-py3-none-any.whl (155 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 155.3/155.3 kB 8.0 MB/s eta 0:00:00
Installing collected packages: charset-normalizer, urllib3, idna, certifi, requests
Successfully installed certifi-2022.12.7 charset-normalizer-3.0.1 idna-3.4 requests-2.28.2 urllib3-1.26.14
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Removing intermediate container 0e41a21ddf10
 ---> 62bd75d92aeb
Step 5/6 : COPY . ./
 ---> c3fca771815d
Step 6/6 : CMD [ "python", "remote_command_execution_vulnerability.py" ]
 ---> Running in c2b76c6f77f0
Removing intermediate container c2b76c6f77f0
 ---> e72eaf026e0b
Successfully built e72eaf026e0b
Successfully tagged openwrtinvasion:latest
```

Layers disk usage:
```
$ docker images -a
REPOSITORY                    TAG       IMAGE ID       CREATED          SIZE
openwrtinvasion               latest    e72eaf026e0b   34 seconds ago   1.06GB
<none>                        <none>    c3fca771815d   35 seconds ago   1.06GB
<none>                        <none>    62bd75d92aeb   36 seconds ago   948MB
<none>                        <none>    f1218ec7f817   40 seconds ago   934MB
<none>                        <none>    44fed244e89b   40 seconds ago   934MB
python                        3         63490c269128   6 hours ago      934MB
```

Switch base layer to alpine and add `.git` history to `.dockerignore`:

```
$ docker build -t openwrtinvasion:alpine .
Sending build context to Docker daemon  46.41MB
Step 1/6 : FROM docker.io/library/python:3-alpine
3-alpine: Pulling from library/python
8921db27df28: Pull complete 
3fd9832a787c: Pull complete 
6bd94263bbe1: Pull complete 
28d26ab7708e: Pull complete 
606d64b2ff70: Pull complete 
Digest: sha256:588a955ecdd370164f2f8814db82e649f542298120225993fd3755334af0fff8
Status: Downloaded newer image for python:3-alpine
 ---> 407b57cd39cc
Step 2/6 : WORKDIR /app
 ---> Running in b3b97685fc8f
Removing intermediate container b3b97685fc8f
 ---> 648255864fb9
Step 3/6 : COPY requirements.txt ./
 ---> 89fac1337b98
Step 4/6 : RUN pip install -r requirements.txt
 ---> Running in 56e7a6945862
Collecting requests
  Downloading requests-2.28.2-py3-none-any.whl (62 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.8/62.8 kB 948.5 kB/s eta 0:00:00
Collecting charset-normalizer<4,>=2
  Downloading charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl (190 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 190.6/190.6 kB 3.3 MB/s eta 0:00:00
Collecting idna<4,>=2.5
  Downloading idna-3.4-py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.5/61.5 kB 6.0 MB/s eta 0:00:00
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.14-py2.py3-none-any.whl (140 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.6/140.6 kB 6.3 MB/s eta 0:00:00
Collecting certifi>=2017.4.17
  Downloading certifi-2022.12.7-py3-none-any.whl (155 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 155.3/155.3 kB 7.6 MB/s eta 0:00:00
Installing collected packages: charset-normalizer, urllib3, idna, certifi, requests
Successfully installed certifi-2022.12.7 charset-normalizer-3.0.1 idna-3.4 requests-2.28.2 urllib3-1.26.14
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Removing intermediate container 56e7a6945862
 ---> 75c4910b30e1
Step 5/6 : COPY . ./
 ---> 2fa7fb4916ab
Step 6/6 : CMD [ "python", "remote_command_execution_vulnerability.py" ]
 ---> Running in dfbd49a3419f
Removing intermediate container dfbd49a3419f
 ---> 4a4447546407
Successfully built 4a4447546407
Successfully tagged openwrtinvasion:alpine
```

And layers sizes:
```
$ docker images -a
REPOSITORY                    TAG        IMAGE ID       CREATED          SIZE
<none>                        <none>     33c0f630ca19   9 seconds ago    113MB
openwrtinvasion               alpine     c52880897b01   9 seconds ago    113MB
<none>                        <none>     bf85979e66ea   10 seconds ago   66.5MB
<none>                        <none>     c73dbb5d1b4f   16 seconds ago   52.4MB
<none>                        <none>     2465df6eec17   16 seconds ago   52.4MB
python                        3-alpine   407b57cd39cc   6 hours ago      52.4MB
```

113MB < 1.06GB

![Nice](https://media.giphy.com/media/yJFeycRK2DB4c/giphy.gif)