### PR TITLE
Ensure correct line ending for script.sh when running in windows

### DIFF
--- a/remote_command_execution_vulnerability.py
+++ b/remote_command_execution_vulnerability.py
@@ -25,9 +25,13 @@ import hashlib
 import platform
 import socket
 
+# make sure that script.sh on windows uses \n
 if platform.system() == "Windows":
-    sys.exit("Stopping: script can only be run on a Mac/Linux system")
-    
+    with open("script.sh", "rt", encoding = "UTF-8") as f:
+        content = f.read()
+    with open("script.sh", "wt", encoding = "UTF-8", newline="\n") as f:
+        f.write(content)
+
 router_ip_address="miwifi.com"
 #router_ip_address = "192.168.31.1"
 router_ip_address = input("Router IP address [press enter for using the default '{}']: ".format(router_ip_address)) or router_ip_address


### PR DESCRIPTION
Changing the line endings in script.sh to \n in windows so the script is running without the need for Linux.
Tested with Mi Router 4  2.26.175.

Python 3.11.0
Windows 22H2 

Output of execution:
`
c:\Python311\python.exe remote_command_execution_vulnerability.py
Router IP address [press enter for using the default 'miwifi.com']: 192.168.31.1
Enter router admin password: xxxxxxx
There two options to provide the files needed for invasion:
   1. Use a local TCP file server runing on random port to provide files in local directory `script_tools`.
   2. Download needed files from remote github repository. (choose this option only if github is accessable inside router device.)
Which option do you prefer? (default: 1)1
****************
router_ip_address: 192.168.31.1
stok: 545495143f25d92720debf6797df1236
file provider: local file server
****************
start uploading config file...
start exec command...
local file server is runing on 0.0.0.0:14880. root='script_tools'
local file server is getting 'busybox-mipsel' for 192.168.31.1.
local file server is getting 'dropbearStaticMipsel.tar.bz2' for 192.168.31.1.
done! Now you can connect to the router using several options: (user: root, password: root)
* telnet 192.168.31.1
* ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -oHostKeyAlgorithms=+ssh-rsa -c 3des-cbc -o UserKnownHostsFile=/dev/null root@192.168.31.1
* ftp: using a program like cyberduck`